### PR TITLE
Adiciona lógica de reprocessamento de dados

### DIFF
--- a/sm_cloud_run/app.py
+++ b/sm_cloud_run/app.py
@@ -6,8 +6,8 @@ from flask import Flask, request, jsonify
 
 from etl.datasus_ftp_metadados import upsert_dados_no_postgres
 
-from etl.siasus_procedimentos_ambulatoriais import baixar_e_processar_pa
-from load_bd.siasus_procedimentos_ambulatoriais_l_bd import inserir_pa_postgres
+from etl.siasus_procedimentos_ambulatoriais import verificar_e_executar
+from load_bd.siasus_procedimentos_ambulatoriais_l_bd import verificar_e_executar
 
 from etl.siasus_bpa_individualizado import baixar_e_processar_bpa_i
 from load_bd.siasus_bpa_individualizado_l_bd import inserir_bpa_i_postgres
@@ -34,7 +34,7 @@ def sm_pa():
 
     data_datetime = datetime.datetime.strptime(json_params['data'], "%Y-%m-%d")
 
-    return jsonify(baixar_e_processar_pa(json_params['UF'], data_datetime))
+    return jsonify(verificar_e_executar(json_params['UF'], data_datetime))
 
 
 @app.route("/pa_postgres", methods=['POST'])
@@ -47,7 +47,7 @@ def load_pa():
 
     data_datetime = datetime.datetime.strptime(json_params['data'], "%Y-%m-%d")
 
-    return jsonify(inserir_pa_postgres(json_params['UF'], data_datetime, json_params['tabela_destino']))
+    return jsonify(verificar_e_executar(json_params['UF'], data_datetime, json_params['tabela_destino']))
 
 
 @app.route("/bpa_i", methods=['POST'])

--- a/sm_cloud_run/etl/siasus_procedimentos_ambulatoriais.py
+++ b/sm_cloud_run/etl/siasus_procedimentos_ambulatoriais.py
@@ -18,13 +18,14 @@ import janitor
 from frozendict import frozendict
 from uuid6 import uuid7
 from sqlalchemy.orm import Session
+from sqlalchemy import select, or_, null
 from utilitarios.config_painel_sm import municipios_painel, condicoes_pa, inserir_timestamp_ftp_metadados
 
 # Utilitarios
 from utilitarios.datasus_ftp import extrair_dbc_lotes
 from utilitarios.datas import agora_gmt_menos3, periodo_por_data
 from utilitarios.geografias import id_sus_para_id_impulso
-from utilitarios.bd_config import Sessao
+from utilitarios.bd_config import Sessao, tabelas
 from utilitarios.cloud_storage import upload_to_bucket
 from utilitarios.logger_config import logger_config
 
@@ -475,13 +476,69 @@ def baixar_e_processar_pa(uf_sigla: str, periodo_data_inicio: datetime.date):
 
 
 
+
+def verificar_e_executar(
+    uf_sigla: str, 
+    periodo_data_inicio: datetime.date
+):
+    
+    logging.info(
+        f"Verificando se PA de {uf_sigla} ({periodo_data_inicio:%y%m}) precisa ser baixado..."
+    )
+    sessao = Sessao()
+        
+    tabela_metadados_ftp = tabelas["saude_mental.sm_metadados_ftp"]          
+
+    # Construa a query usando SQL Core
+    consulta = (
+        select(tabela_metadados_ftp)
+        .where(
+            tabela_metadados_ftp.c.tipo == 'PA',
+            tabela_metadados_ftp.c.sigla_uf == uf_sigla,
+            tabela_metadados_ftp.c.processamento_periodo_data_inicio == periodo_data_inicio,
+            or_(
+                tabela_metadados_ftp.c.timestamp_modificacao_ftp > tabela_metadados_ftp.c.timestamp_etl_gcs,
+                tabela_metadados_ftp.c.timestamp_etl_gcs.is_(null())
+            )
+        )
+    )
+
+    # Execute a consulta usando `session.execute` com a expressão SQL Core
+    resultado = sessao.execute(consulta).fetchone()
+
+    if resultado:
+        logging.info(
+        f"Verificação concluída. Iniciando processo de download."
+        )
+        # Se existir algum registro, executa a função
+        baixar_e_processar_pa(uf_sigla, periodo_data_inicio)    
+    
+    else:
+        # Obter sumário de resposta
+        response = {
+            "status": "Skipped",
+            "estado": uf_sigla,
+            "periodo": f"{periodo_data_inicio:%y%m}"
+        }
+
+        logging.info(
+            "Essa combinação já foi baixada e é a mais atual. "
+            f"Nenhum dado foi baixado para {uf_sigla} ({periodo_data_inicio:%y%m})."
+        )
+
+        sessao.close()    
+
+        return response
+
+
+
 # RODAR LOCALMENTE
 if __name__ == "__main__":
     from datetime import datetime
 
     # Define os parâmetros de teste
     uf_sigla = "AL"
-    periodo_data_inicio = datetime.strptime("2024-02-01", "%Y-%m-%d").date()
+    periodo_data_inicio = datetime.strptime("2024-06-01", "%Y-%m-%d").date()
 
     # Chama a função principal com os parâmetros de teste
-    baixar_e_processar_pa(uf_sigla, periodo_data_inicio)
+    verificar_e_executar(uf_sigla, periodo_data_inicio)


### PR DESCRIPTION
# Descrição
Considerando o cenário de necessidade de reprocessamento de dados em até 12 meses, em adição ao processo já previsto de processamento mensal de novas competências, esse PR contempla a necessidade que surgiu de:
1. Criar um processo efetivo para deleção dos registros quando há a necessidade deles serem reprocessados, afim de evitar duplicatas de dados;
2. Criar processo de checagem de necessidade de processamento de cada combinação de UF e competência, afim de garantir que só estamos processando aqueles dados que realmente são necessários.

# Objetivos
1. Implementar lógica de deleção de registros no momento da inserção:
[feat: 🗃️ Adiciona lógica de deleção de registros](https://github.com/ImpulsoGov/sm-etl-cloud-run/commit/b3dcfd4d37e460e16df995788684035969ae46cc)

2. Implementar lógica de checagem de (re)processamento da combinação acionada:
[feat: 🔨 Insere lógica de checagem de necessidade de processamento/reprocessamento](https://github.com/ImpulsoGov/sm-etl-cloud-run/commit/9c68d82c8c8268cd72fad85a1342887d69afa9e0) 
    🔍🔀 Observação: Inicialmente esse processo de checagem foi implementado via Airflow, buscando o acionamento apenas daquelas tasks que precisam ser (re)processadas. Entretanto, a criação de tasks dinâmicas não permitiu boa observabilidade do processo de orquestração desse ETL, além de retornar resultados inesperados para as execuções, uma vez que a lista dinâmica de tasks sofria alterações enquanto a DAG ainda estava em execução. 
     O caminho escolhido foi implementar essa lógica de checagem dentro do CloudRun, uma vez que havia a impossibilidade de alterar diretamente qualquer parâmetro de intervalo de atualização de processo do Airflow (alteração que poderia ocasionar erros nas demais DAGs já implementadas).
